### PR TITLE
Response security details

### DIFF
--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -266,6 +266,9 @@ class ScrapyPlaywrightDownloadHandler(HTTPDownloadHandler):
             server_addr = await response.server_addr()
             server_ip_address = ip_address(server_addr["ipAddress"])
 
+        with suppress(AttributeError):
+            request.meta["playwright_security_details"] = await response.security_details()
+
         headers = Headers(response.headers)
         headers.pop("Content-Encoding", None)
         encoding = _get_response_encoding(headers, body_str) or "utf-8"


### PR DESCRIPTION
Requested at #66.

Not added in the `Response.certificate` attribute because the full certificate is not available, this is just some information _about_ the certificate.