### PR TITLE
Warn on failed requests

### DIFF
--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -384,6 +384,7 @@ def _encode_body(headers: Headers, text: str) -> Tuple[bytes, str]:
 
 def _is_safe_close_error(error: Exception) -> bool:
     """
+    Taken verbatim from
     https://github.com/microsoft/playwright-python/blob/v1.20.0/playwright/_impl/_helper.py#L234-L238
     """
     message = str(error)

--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -223,10 +223,8 @@ class ScrapyPlaywrightDownloadHandler(HTTPDownloadHandler):
         try:
             result = await self._download_request_with_page(request, page)
         except Exception as ex:
-            if not page.is_closed():
-                logger.warning(
-                    f"{request}: failed processing Scrapy request ({type(ex)}), closing page"
-                )
+            if not request.meta.get("playwright_include_page") and not page.is_closed():
+                logger.warning(f"Closing page due to failed request: {request} ({type(ex)})")
                 await page.close()
                 self.stats.inc_value("playwright/page_count/closed")
             raise

--- a/tests/test_playwright_requests.py
+++ b/tests/test_playwright_requests.py
@@ -179,8 +179,7 @@ class MixinTestCase:
                 assert (
                     "scrapy-playwright",
                     logging.WARNING,
-                    f"{req}: failed processing Scrapy request"
-                    f" ({type(excinfo.value)}), closing page",
+                    f"Closing page due to failed request: {req} ({type(excinfo.value)})",
                 ) in caplog.record_tuples
 
     @pytest.mark.skipif(sys.version_info < (3, 8), reason="Fails on py37")

--- a/tests/test_playwright_requests.py
+++ b/tests/test_playwright_requests.py
@@ -180,23 +180,23 @@ class MixinTestCase:
     @pytest.mark.asyncio
     async def test_route_continue_exception(self, logger):
         async with make_handler({"PLAYWRIGHT_BROWSER_TYPE": self.browser_type}) as handler:
-            req_handler = handler._make_request_handler("GET", Headers({}), b"")
+            req_handler = handler._make_request_handler("GET", Headers({}), body=None)
+            route = MagicMock()
+            playwright_request = MagicMock()
+            playwright_request.url = "https//example.org"
 
             # safe error, only warn
             exc = Exception("Target page, context or browser has been closed")
-            route_safe = MagicMock()
-            route_safe.continue_.side_effect = exc
-            playwright_request = MagicMock()
-            await req_handler(route_safe, playwright_request)
+            route.continue_.side_effect = exc
+            await req_handler(route, playwright_request)
             logger.warning.assert_called_with(
                 f"{playwright_request}: failed processing Playwright request ({exc})"
             )
 
             # unknown error, re-raise
-            route_unknown = MagicMock()
-            route_unknown.continue_.side_effect = ZeroDivisionError("asdf")
+            route.continue_.side_effect = ZeroDivisionError("asdf")
             with pytest.raises(ZeroDivisionError):
-                await req_handler(route_unknown, playwright_request=MagicMock())
+                await req_handler(route, playwright_request)
 
     @pytest.mark.asyncio
     async def test_context_kwargs(self):

--- a/tests/test_playwright_requests.py
+++ b/tests/test_playwright_requests.py
@@ -2,6 +2,7 @@ import json
 import logging
 import platform
 import subprocess
+import sys
 from ipaddress import ip_address
 from tempfile import NamedTemporaryFile
 from unittest.mock import MagicMock, patch
@@ -182,9 +183,14 @@ class MixinTestCase:
                     f" ({type(excinfo.value)}), closing page",
                 ) in caplog.record_tuples
 
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="Fails on py37")
     @patch("scrapy_playwright.handler.logger")
     @pytest.mark.asyncio
     async def test_route_continue_exception(self, logger):
+        """This test fails on Python 3.7 in the "logger.warning.assert_called_with" assertion,
+        but the "Captured log call" section shows the exact message that is expected.
+        ¯\_(ツ)_/¯
+        """
         async with make_handler({"PLAYWRIGHT_BROWSER_TYPE": self.browser_type}) as handler:
             req_handler = handler._make_request_handler("GET", Headers({}), body=None)
             route = MagicMock()

--- a/tests/test_playwright_requests.py
+++ b/tests/test_playwright_requests.py
@@ -188,8 +188,7 @@ class MixinTestCase:
     @pytest.mark.asyncio
     async def test_route_continue_exception(self, logger):
         """This test fails on Python 3.7 in the "logger.warning.assert_called_with" assertion,
-        but the "Captured log call" section shows the exact message that is expected.
-        ¯\_(ツ)_/¯
+        but the "Captured log call" section shows the exact message that is expected :shrug:
         """
         async with make_handler({"PLAYWRIGHT_BROWSER_TYPE": self.browser_type}) as handler:
             req_handler = handler._make_request_handler("GET", Headers({}), body=None)


### PR DESCRIPTION
Closes #15

In #15, a `TimeoutError` causes the following:
* [This line](https://github.com/scrapy-plugins/scrapy-playwright/blob/v0.0.14/scrapy_playwright/handler.py#L241) fails ([here](https://github.com/scrapy-plugins/scrapy-playwright/blob/v0.0.14/scrapy_playwright/handler.py#L252), to be precise), so the `except` block closes the page which handled the request to avoid having unused pages consuming memory
* Then [this line](https://github.com/scrapy-plugins/scrapy-playwright/blob/v0.0.14/scrapy_playwright/handler.py#L370) fails with the "Target page, context or browser has been closed" message, because the page was indeed closed

The first exception can be handled with a [request errback](https://docs.scrapy.org/en/latest/topics/request-response.html#using-errbacks-to-catch-exceptions-in-request-processing) or a spider middleware with a [`process_spider_exception`](https://docs.scrapy.org/en/latest/topics/spider-middleware.html#scrapy.spidermiddlewares.SpiderMiddleware.process_spider_exception), so recovery measures can be taken. The only way I can think of avoiding the second one is not closing the page on failure, I don't think that's a good idea (this avoids having unclosed pages floating around consuming memory) but I'm open to be proven wrong. With the current situation, it's just confusing for the users so let's just catch it and log a message.

This patch is mostly to warn in the logs instead of failing loudly, as the error can be handled with Scrapy's existing API (errbacks, spider middleware's process_spider_exception).

A sample spider:

```python
import scrapy

class ErrbackSpider(scrapy.Spider):
    name = "error"
    custom_settings = {
        "LOG_LEVEL": "INFO",
        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
        "DOWNLOAD_HANDLERS": {
            "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
            # "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
        },
        "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 1,
    }

    def start_requests(self):
        yield scrapy.Request(
            url="https://example.org",
            meta={"playwright": True},
            errback=self.errback,
        )

    async def errback(self, failure):
        print("Request:", failure.request)
        print("Exception class:", type(failure.value))
        print("Exception message:", failure.value)

```

```
2022-03-29 18:34:33 [scrapy.core.engine] INFO: Spider opened
2022-03-29 18:34:33 [scrapy.extensions.logstats] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
2022-03-29 18:34:35 [scrapy-playwright] INFO: Launching browser
2022-03-29 18:34:35 [scrapy-playwright] INFO: Browser chromium launched
2022-03-29 18:34:39 [scrapy-playwright] WARNING: Closing page due to failed request: <GET https://example.org> (<class 'playwright._impl._api_types.TimeoutError'>)
2022-03-29 18:34:39 [scrapy-playwright] WARNING: <Request url='https://example.org/' method='GET'>: failed processing Playwright request (Target page, context or browser has been closed)
Request: <GET https://example.org>
Exception class: <class 'playwright._impl._api_types.TimeoutError'>
Exception message: Timeout 1ms exceeded.
=========================== logs ===========================
navigating to "https://example.org/", waiting until "load"
============================================================
2022-03-29 18:34:39 [scrapy.core.engine] INFO: Closing spider (finished)
```