### PR TITLE
Use new headers API from Playwright 1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,16 @@ TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
     the default value will be used (30000 ms at the time of writing this).
     See the docs for [BrowserContext.set_default_navigation_timeout](https://playwright.dev/python/docs/api/class-browsercontext#browser-context-set-default-navigation-timeout).
 
-* `PLAYWRIGHT_PROCESS_REQUEST_HEADERS` (type `Union[Callable, str]`, default `scrapy_playwright.headers.use_scrapy_headers`)
+* `PLAYWRIGHT_PROCESS_REQUEST_HEADERS` (type `Optional[Union[Callable, str]]`, default `scrapy_playwright.headers.use_scrapy_headers`)
 
     A function (or the path to a function) that processes headers for a given request
     and returns a dictionary with the headers to be used (note that, depending on the browser,
-    additional default headers will be sent as well). Coroutine functions (`async def`) are
+    additional default headers could be sent as well). Coroutine functions (`async def`) are
     supported.
+
+    This will be called at least once for each Scrapy request (receiving said request and the
+    corresponding Playwright request), but it could be called additional times if the given
+    resource generates more requests (e.g. to retrieve assets like images or scripts).
 
     The function must return a `dict` object, and receives the following keyword arguments:
 
@@ -117,9 +121,10 @@ TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
     For non-navigation requests (e.g. images, stylesheets, scripts, etc), only the `User-Agent` header
     is overriden, for consistency.
 
-    There is another alternative available: `scrapy_playwright.headers.use_playwright_headers`.
-    Use this if you want the headers from the Playwright request to be used without changes.
-    When doing so, please keep in mind that headers passed via the `Request.headers` attribute
+    Setting `PLAYWRIGHT_PROCESS_REQUEST_HEADERS=None` will give complete control of the headers to
+    Playwright, i.e. headers from Scrapy requests will be ignored and only headers set by
+    Playwright will be sent.
+    When doing this, please keep in mind that headers passed via the `Request.headers` attribute
     or set by Scrapy components are ignored (including cookies set via the `Request.cookies`
     attribute).
 
@@ -561,6 +566,12 @@ may be removed at any time. See the [changelog](changelog.md)
 for more information about deprecations and removals.
 
 ### Currently deprecated features
+
+* `scrapy_playwright.headers.use_playwright_headers` function
+
+    Deprecated since
+    [`v0.0.16`](https://github.com/scrapy-plugins/scrapy-playwright/releases/tag/v0.0.16),
+    set `PLAYWRIGHT_PROCESS_REQUEST_HEADERS=None` instead
 
 * `scrapy_playwright.page.PageCoroutine` class
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
 
     There is another alternative available: `scrapy_playwright.headers.use_playwright_headers`.
     Use this if you want the headers from the Playwright request to be used without changes.
-    When using this, please keep in mind that headers passed via the `Request.headers` attribute
+    When doing so, please keep in mind that headers passed via the `Request.headers` attribute
     or set by Scrapy components are ignored (including cookies set via the `Request.cookies`
     attribute).
 

--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
     For non-navigation requests (e.g. images, stylesheets, scripts, etc), only the `User-Agent` header
     is overriden, for consistency.
 
-    There is another built-in function available: `scrapy_playwright.headers.use_playwright_headers`,
-    which will return the headers from the Playwright request unmodified.
-    When using this alternative, please keep in mind that headers passed via the `Request.headers`
-    attribute or set by Scrapy components are ignored (including cookies set via the `Request.cookies`
+    There is another alternative available: `scrapy_playwright.headers.use_playwright_headers`.
+    Use this if you want the headers from the Playwright request to be used without changes.
+    When using this, please keep in mind that headers passed via the `Request.headers` attribute
+    or set by Scrapy components are ignored (including cookies set via the `Request.cookies`
     attribute).
 
 * `PLAYWRIGHT_MAX_PAGES_PER_CONTEXT` (type `int`, defaults to the value of Scrapy's `CONCURRENT_REQUESTS` setting)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ to integrate `asyncio`-based projects such as `Playwright`.
 
 * Python >= 3.7
 * Scrapy >= 2.0 (!= 2.4.0)
-* Playwright >= 1.8.0a1
+* Playwright >= 1.15
 
 
 ## Installation

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # scrapy-playwright changelog
 
+
+### v0.0.16 (2022-NN-NN)
+
+* Use new headers API introduced in Playwright 1.15 (bump required Playwright version)
+
+
 ### [v0.0.15](https://github.com/scrapy-plugins/scrapy-playwright/releases/tag/v0.0.15) (2022-05-08)
 
 * Remove deprecated `PLAYWRIGHT_CONTEXT_ARGS` setting

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,10 @@
 # scrapy-playwright changelog
 
 
-### v0.0.16 (2022-NN-NN)
+### [v0.0.16](https://github.com/scrapy-plugins/scrapy-playwright/releases/tag/v0.0.16) (2022-NN-NN)
 
 * Use new headers API introduced in Playwright 1.15 (bump required Playwright version)
+* Deprecate `scrapy_playwright.headers.use_playwright_headers`, set `PLAYWRIGHT_PROCESS_REQUEST_HEADERS=None` instead
 
 
 ### [v0.0.15](https://github.com/scrapy-plugins/scrapy-playwright/releases/tag/v0.0.15) (2022-05-08)

--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -233,7 +233,7 @@ class ScrapyPlaywrightDownloadHandler(HTTPDownloadHandler):
         with suppress(AttributeError):
             request.meta["playwright_security_details"] = await response.security_details()
 
-        headers = Headers(response.headers)
+        headers = Headers(await response.all_headers())
         headers.pop("Content-Encoding", None)
         body, encoding = _encode_body(headers=headers, text=body_str)
         respcls = responsetypes.from_args(headers=headers, url=page.url, body=body)
@@ -351,20 +351,22 @@ async def _await_if_necessary(obj):
 
 
 def _make_request_logger(context_name: str) -> Callable:
-    def _log_request(request: PlaywrightRequest) -> None:
+    async def _log_request(request: PlaywrightRequest) -> None:
+        referrer = await request.header_value("referer")
         logger.debug(
             f"[Context={context_name}] Request: <{request.method.upper()} {request.url}> "
-            f"(resource type: {request.resource_type}, referrer: {request.headers.get('referer')})"
+            f"(resource type: {request.resource_type}, referrer: {referrer})"
         )
 
     return _log_request
 
 
 def _make_response_logger(context_name: str) -> Callable:
-    def _log_request(response: PlaywrightResponse) -> None:
+    async def _log_request(response: PlaywrightResponse) -> None:
+        referrer = await response.header_value("referer")
         logger.debug(
             f"[Context={context_name}] Response: <{response.status} {response.url}> "
-            f"(referrer: {response.headers.get('referer')})"
+            f"(referrer: {referrer})"
         )
 
     return _log_request

--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -61,12 +61,22 @@ class ScrapyPlaywrightDownloadHandler(HTTPDownloadHandler):
                     crawler.settings.get("PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT")
                 )
 
-        if crawler.settings.get("PLAYWRIGHT_PROCESS_REQUEST_HEADERS"):
-            self.process_request_headers = load_object(
-                crawler.settings["PLAYWRIGHT_PROCESS_REQUEST_HEADERS"]
-            )
-            if self.process_request_headers is use_playwright_headers:
-                self.process_request_headers = None
+        if "PLAYWRIGHT_PROCESS_REQUEST_HEADERS" in crawler.settings:
+            if crawler.settings["PLAYWRIGHT_PROCESS_REQUEST_HEADERS"] is None:
+                self.process_request_headers = None  # use headers from the Playwright request
+            else:
+                self.process_request_headers = load_object(
+                    crawler.settings["PLAYWRIGHT_PROCESS_REQUEST_HEADERS"]
+                )
+                if self.process_request_headers is use_playwright_headers:
+                    warnings.warn(
+                        "The 'scrapy_playwright.headers.use_playwright_headers' function is"
+                        " deprecated, please set 'PLAYWRIGHT_PROCESS_REQUEST_HEADERS=None'"
+                        " instead.",
+                        category=ScrapyDeprecationWarning,
+                        stacklevel=1,
+                    )
+                    self.process_request_headers = None
         else:
             self.process_request_headers = use_scrapy_headers
 

--- a/scrapy_playwright/headers.py
+++ b/scrapy_playwright/headers.py
@@ -36,7 +36,7 @@ async def use_scrapy_headers(
 
 
 def use_playwright_headers(*args, **kwargs) -> None:
-    """Used to signal that the default browser headers should be used unmodified.
-    The fact that this is a function is a hack, otherwise `scrapy.utils.misc.load_object`
+    """Indicate that the headers from the Playwright request should be used, unmodified.
+    This being a callable is an ugly hack, otherwise `scrapy.utils.misc.load_object`
     would fail when loading it."""
     return None

--- a/scrapy_playwright/headers.py
+++ b/scrapy_playwright/headers.py
@@ -35,10 +35,8 @@ async def use_scrapy_headers(
     return playwright_headers
 
 
-async def use_playwright_headers(
-    browser_type: str,
-    playwright_request: PlaywrightRequest,
-    scrapy_headers: Headers,
-) -> dict:
-    """Return headers from the Playwright request, unaltered"""
-    return await playwright_request.all_headers()
+def use_playwright_headers(*args, **kwargs) -> None:
+    """Used to signal that the default browser headers should be used unmodified.
+    The fact that this is a function is a hack, otherwise `scrapy.utils.misc.load_object`
+    would fail when loading it."""
+    return None

--- a/scrapy_playwright/headers.py
+++ b/scrapy_playwright/headers.py
@@ -2,10 +2,11 @@
 This module includes functions to process request headers.
 Refer to the PLAYWRIGHT_PROCESS_REQUEST_HEADERS setting for more information.
 """
-
+import warnings
 from urllib.parse import urlparse
 
 from playwright.async_api import Request as PlaywrightRequest
+from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.http.headers import Headers
 
 
@@ -35,8 +36,16 @@ async def use_scrapy_headers(
     return playwright_headers
 
 
-def use_playwright_headers(*args, **kwargs) -> None:
-    """Indicate that the headers from the Playwright request should be used, unmodified.
-    This being a callable is an ugly hack, otherwise `scrapy.utils.misc.load_object`
-    would fail when loading it."""
-    return None
+async def use_playwright_headers(
+    browser_type: str,
+    playwright_request: PlaywrightRequest,
+    scrapy_headers: Headers,
+) -> dict:
+    warnings.warn(
+        "The 'scrapy_playwright.headers.use_playwright_headers' function is"
+        " deprecated, please set 'PLAYWRIGHT_PROCESS_REQUEST_HEADERS=None'"
+        " instead.",
+        category=ScrapyDeprecationWarning,
+        stacklevel=1,
+    )
+    return await playwright_request.all_headers()

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,6 @@ setuptools.setup(
     python_requires=">=3.7",
     install_requires=[
         "scrapy>=2.0,!=2.4.0",
-        "playwright>=1.8.0a1",
+        "playwright>=1.15",
     ],
 )

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -1,0 +1,133 @@
+import json
+import platform
+import warnings
+
+import pytest
+from scrapy import Spider, Request
+
+from tests import make_handler
+from tests.mockserver import MockServer
+
+from scrapy_playwright.headers import use_playwright_headers
+
+
+class MixinProcessHeadersTestCase:
+    @pytest.mark.asyncio
+    async def test_user_agent(self):
+        settings_dict = {
+            "PLAYWRIGHT_BROWSER_TYPE": self.browser_type,
+            "PLAYWRIGHT_CONTEXTS": {"default": {"user_agent": self.browser_type}},
+            "USER_AGENT": None,
+        }
+        async with make_handler(settings_dict) as handler:
+            with MockServer() as server:
+                # if Scrapy's user agent is None, use the one from the Browser
+                req = Request(
+                    url=server.urljoin("/headers"),
+                    meta={"playwright": True},
+                )
+                resp = await handler._download_request(req, Spider("foo"))
+                headers = json.loads(resp.css("pre::text").get())
+                headers = {key.lower(): value for key, value in headers.items()}
+                assert headers["user-agent"] == self.browser_type
+
+                # if Scrapy's user agent is set to some value, use it
+                req = Request(
+                    url=server.urljoin("/headers"),
+                    meta={"playwright": True},
+                    headers={"User-Agent": "foobar"},
+                )
+                resp = await handler._download_request(req, Spider("foo"))
+                headers = json.loads(resp.css("pre::text").get())
+                headers = {key.lower(): value for key, value in headers.items()}
+                assert headers["user-agent"] == "foobar"
+
+    @pytest.mark.asyncio
+    async def test_use_playwright_headers(self):
+        """Ignore Scrapy headers"""
+        settings_dict = {
+            "PLAYWRIGHT_BROWSER_TYPE": self.browser_type,
+            "PLAYWRIGHT_CONTEXTS": {"default": {"user_agent": self.browser_type}},
+            "PLAYWRIGHT_PROCESS_REQUEST_HEADERS": None,
+            "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 2000,
+        }
+        async with make_handler(settings_dict) as handler:
+            with MockServer() as server:
+                req = Request(
+                    url=server.urljoin("/headers"),
+                    meta={"playwright": True},
+                    headers={"User-Agent": "foobar", "Asdf": "qwerty"},
+                )
+                resp = await handler._download_request(req, Spider("foo"))
+                headers = json.loads(resp.css("pre::text").get())
+                headers = {key.lower(): value for key, value in headers.items()}
+                assert headers["user-agent"] == self.browser_type
+                assert "asdf" not in headers
+
+    @pytest.mark.asyncio
+    async def test_use_playwright_headers_deprecated(self):
+        """Ignore Scrapy headers"""
+        settings_dict = {
+            "PLAYWRIGHT_BROWSER_TYPE": self.browser_type,
+            "PLAYWRIGHT_CONTEXTS": {"default": {"user_agent": self.browser_type}},
+            "PLAYWRIGHT_PROCESS_REQUEST_HEADERS": use_playwright_headers,
+            "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 2000,
+        }
+        with warnings.catch_warnings(record=True) as warning_list:
+            async with make_handler(settings_dict) as handler:
+                with MockServer() as server:
+                    req = Request(
+                        url=server.urljoin("/headers"),
+                        meta={"playwright": True},
+                        headers={"User-Agent": "foobar", "Asdf": "qwerty"},
+                    )
+                    resp = await handler._download_request(req, Spider("foo"))
+                    headers = json.loads(resp.css("pre::text").get())
+                    headers = {key.lower(): value for key, value in headers.items()}
+                    assert headers["user-agent"] == self.browser_type
+                    assert "asdf" not in headers
+
+            assert str(warning_list[0].message) == (
+                "The 'scrapy_playwright.headers.use_playwright_headers' function is"
+                " deprecated, please set 'PLAYWRIGHT_PROCESS_REQUEST_HEADERS=None'"
+                " instead."
+            )
+
+    @pytest.mark.asyncio
+    async def test_use_custom_headers(self):
+        """Custom header processing function"""
+
+        async def important_headers(*args, **kwargs) -> dict:
+            return {"foo": "bar"}
+
+        settings_dict = {
+            "PLAYWRIGHT_BROWSER_TYPE": self.browser_type,
+            "PLAYWRIGHT_CONTEXTS": {"default": {"user_agent": self.browser_type}},
+            "PLAYWRIGHT_PROCESS_REQUEST_HEADERS": important_headers,
+        }
+        async with make_handler(settings_dict) as handler:
+            with MockServer() as server:
+                req = Request(
+                    url=server.urljoin("/headers"),
+                    meta={"playwright": True},
+                    headers={"User-Agent": "foobar", "Asdf": "qwerty"},
+                )
+                resp = await handler._download_request(req, Spider("foo"))
+                headers = json.loads(resp.css("pre::text").get())
+                headers = {key.lower(): value for key, value in headers.items()}
+                assert headers["foo"] == "bar"
+                assert headers.get("user-agent") not in (self.browser_type, "foobar")
+                assert "asdf" not in headers
+
+
+class TestProcessHeadersChromium(MixinProcessHeadersTestCase):
+    browser_type = "chromium"
+
+
+class TestProcessHeadersFirefox(MixinProcessHeadersTestCase):
+    browser_type = "firefox"
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Test WebKit only on Darwin")
+class TestProcessHeadersWebkit(MixinProcessHeadersTestCase):
+    browser_type = "webkit"

--- a/tests/test_playwright_requests.py
+++ b/tests/test_playwright_requests.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import platform
 import subprocess
@@ -193,6 +192,7 @@ class MixinTestCase:
             route = MagicMock()
             playwright_request = AsyncMock()
             playwright_request.url = "https//example.org"
+            playwright_request.is_navigation_request = MagicMock(return_value=True)
             playwright_request.all_headers.return_value = {}
 
             # safe error, only warn
@@ -272,86 +272,6 @@ class MixinTestCase:
                 pdf_file.file.seek(0)
                 assert pdf_file.file.read() == req.meta["playwright_page_methods"]["pdf"].result
                 assert get_mimetype(pdf_file) == "application/pdf"
-
-    @pytest.mark.asyncio
-    async def test_user_agent(self):
-        settings_dict = {
-            "PLAYWRIGHT_BROWSER_TYPE": self.browser_type,
-            "PLAYWRIGHT_CONTEXTS": {"default": {"user_agent": self.browser_type}},
-            "USER_AGENT": None,
-        }
-        async with make_handler(settings_dict) as handler:
-            with MockServer() as server:
-                # if Scrapy's user agent is None, use the one from the Browser
-                req = Request(
-                    url=server.urljoin("/headers"),
-                    meta={"playwright": True},
-                )
-                resp = await handler._download_request(req, Spider("foo"))
-                headers = json.loads(resp.css("pre::text").get())
-                headers = {key.lower(): value for key, value in headers.items()}
-                assert headers["user-agent"] == self.browser_type
-
-                # if Scrapy's user agent is set to some value, use it
-                req = Request(
-                    url=server.urljoin("/headers"),
-                    meta={"playwright": True},
-                    headers={"User-Agent": "foobar"},
-                )
-                resp = await handler._download_request(req, Spider("foo"))
-                headers = json.loads(resp.css("pre::text").get())
-                headers = {key.lower(): value for key, value in headers.items()}
-                assert headers["user-agent"] == "foobar"
-
-    @pytest.mark.asyncio
-    async def test_use_playwright_headers(self):
-        """Ignore Scrapy headers"""
-        from scrapy_playwright.headers import use_playwright_headers
-
-        settings_dict = {
-            "PLAYWRIGHT_BROWSER_TYPE": self.browser_type,
-            "PLAYWRIGHT_CONTEXTS": {"default": {"user_agent": self.browser_type}},
-            "PLAYWRIGHT_PROCESS_REQUEST_HEADERS": use_playwright_headers,
-            "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 2000,
-        }
-        async with make_handler(settings_dict) as handler:
-            with MockServer() as server:
-                req = Request(
-                    url=server.urljoin("/headers"),
-                    meta={"playwright": True},
-                    headers={"User-Agent": "foobar", "Asdf": "qwerty"},
-                )
-                resp = await handler._download_request(req, Spider("foo"))
-                headers = json.loads(resp.css("pre::text").get())
-                headers = {key.lower(): value for key, value in headers.items()}
-                assert headers["user-agent"] == self.browser_type
-                assert "asdf" not in headers
-
-    @pytest.mark.asyncio
-    async def test_use_custom_headers(self):
-        """Custom header processing function"""
-
-        async def important_headers(*args, **kwargs) -> dict:
-            return {"foo": "bar"}
-
-        settings_dict = {
-            "PLAYWRIGHT_BROWSER_TYPE": self.browser_type,
-            "PLAYWRIGHT_CONTEXTS": {"default": {"user_agent": self.browser_type}},
-            "PLAYWRIGHT_PROCESS_REQUEST_HEADERS": important_headers,
-        }
-        async with make_handler(settings_dict) as handler:
-            with MockServer() as server:
-                req = Request(
-                    url=server.urljoin("/headers"),
-                    meta={"playwright": True},
-                    headers={"User-Agent": "foobar", "Asdf": "qwerty"},
-                )
-                resp = await handler._download_request(req, Spider("foo"))
-                headers = json.loads(resp.css("pre::text").get())
-                headers = {key.lower(): value for key, value in headers.items()}
-                assert headers["foo"] == "bar"
-                assert headers.get("user-agent") not in (self.browser_type, "foobar")
-                assert "asdf" not in headers
 
     @pytest.mark.asyncio
     async def test_event_handler_dialog_callable(self):

--- a/tests/test_playwright_requests.py
+++ b/tests/test_playwright_requests.py
@@ -182,14 +182,10 @@ class MixinTestCase:
                     f"Closing page due to failed request: {req} ({type(excinfo.value)})",
                 ) in caplog.record_tuples
 
-    @pytest.mark.skipif(sys.version_info < (3, 8), reason="Fails on py37")
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="AsyncMock was added on Python 3.8")
     @patch("scrapy_playwright.handler.logger")
     @pytest.mark.asyncio
     async def test_route_continue_exception(self, logger):
-        """This test fails on Python 3.7 in the "logger.warning.assert_called_with" assertion,
-        but the "Captured log call" section shows the exact message that is expected :shrug:
-        Also, AsyncMock is Python 3.8+
-        """
         from unittest.mock import AsyncMock
 
         async with make_handler({"PLAYWRIGHT_BROWSER_TYPE": self.browser_type}) as handler:

--- a/tests/test_playwright_requests.py
+++ b/tests/test_playwright_requests.py
@@ -188,12 +188,16 @@ class MixinTestCase:
     async def test_route_continue_exception(self, logger):
         """This test fails on Python 3.7 in the "logger.warning.assert_called_with" assertion,
         but the "Captured log call" section shows the exact message that is expected :shrug:
+        Also, AsyncMock is Python 3.8+
         """
+        from unittest.mock import AsyncMock
+
         async with make_handler({"PLAYWRIGHT_BROWSER_TYPE": self.browser_type}) as handler:
             req_handler = handler._make_request_handler("GET", Headers({}), body=None)
             route = MagicMock()
-            playwright_request = MagicMock()
+            playwright_request = AsyncMock()
             playwright_request.url = "https//example.org"
+            playwright_request.all_headers.return_value = {}
 
             # safe error, only warn
             exc = Exception("Target page, context or browser has been closed")

--- a/tests/test_playwright_requests.py
+++ b/tests/test_playwright_requests.py
@@ -316,6 +316,7 @@ class MixinTestCase:
             "PLAYWRIGHT_BROWSER_TYPE": self.browser_type,
             "PLAYWRIGHT_CONTEXTS": {"default": {"user_agent": self.browser_type}},
             "PLAYWRIGHT_PROCESS_REQUEST_HEADERS": use_playwright_headers,
+            "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 2000,
         }
         async with make_handler(settings_dict) as handler:
             with MockServer() as server:

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,6 @@ envlist = bandit,black,flake8,typing,pylint,py
 
 [testenv]
 deps =
-    playwright>=1.8.0a1
-    scrapy>=2.0,!=2.4.0
     pytest==6.2.5
     pytest-asyncio==0.10
     pytest-cov==3.0.0


### PR DESCRIPTION
See https://playwright.dev/python/docs/release-notes#version-115

Tasks:
- [x] Use new headers API
- [x]  Deprecate `scrapy_playwright.headers.use_playwright_headers` in favor of setting `PLAYWRIGHT_PROCESS_REQUEST_HEADERS=None`