### PR TITLE
Always override request headers

### DIFF
--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -390,15 +390,18 @@ class ScrapyPlaywrightDownloadHandler(HTTPDownloadHandler):
 
             overrides: dict = {}
 
-            if self.process_request_headers is not None:
-                overrides["headers"] = await _maybe_await(
+            if self.process_request_headers is None:
+                final_headers = await playwright_request.all_headers()
+            else:
+                overrides["headers"] = final_headers = await _maybe_await(
                     self.process_request_headers(
                         self.browser_type_name, playwright_request, scrapy_headers
                     )
                 )
-                # the request that reaches the callback should contain the final headers
-                scrapy_headers.clear()
-                scrapy_headers.update(overrides["headers"])
+            # the request that reaches the callback should contain the final headers
+            scrapy_headers.clear()
+            scrapy_headers.update(final_headers)
+            del final_headers
 
             if playwright_request.is_navigation_request():
                 overrides["method"] = method

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -82,7 +82,10 @@ class MixinProcessHeadersTestCase:
                 headers = json.loads(resp.css("pre::text").get())
                 headers = {key.lower(): value for key, value in headers.items()}
                 assert headers["user-agent"] == self.browser_type
+                assert req.headers["user-agent"].decode("utf-8") == self.browser_type
                 assert "asdf" not in headers
+                assert "asdf" not in req.headers
+                assert b"asdf" not in req.headers
 
     @pytest.mark.asyncio
     async def test_use_playwright_headers_deprecated(self):


### PR DESCRIPTION
Request headers accessed in callbacks do not match actual headers sent to the target website when setting `PLAYWRIGHT_PROCESS_REQUEST_HEADERS=None`:

```python
# headers.py
import json

from scrapy import Spider, Request


class HeadersSpider(Spider):
    name = "headers"
    custom_settings = {
        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
        "DOWNLOAD_HANDLERS": {
            "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
            # "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
        },
        "PLAYWRIGHT_PROCESS_REQUEST_HEADERS": None,
        "USER_AGENT": "Overridden user agent",
    }

    def start_requests(self):
        yield Request(
            url="https://httpbin.org/headers",
            meta={"playwright": True},
        )

    def parse(self, response):
        actual_user_agent = json.loads(response.css("pre::text").get())["headers"]["User-Agent"]
        print("Actual user agent: ", actual_user_agent)
        print("Request user agent:", response.request.headers["user-agent"].decode("utf-8"))
```

Without this patch:
```
$ scrapy runspider headers.py
(...)
Actual user agent:  Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4863.0 Safari/537.36
Request user agent: Overridden user agent
(...)
```

With this patch:
```
$ scrapy runspider headers.py
(...)
Actual user agent:  Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4863.0 Safari/537.36
Request user agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/100.0.4863.0 Safari/537.36
(...)
```

Originally reported in https://github.com/scrapy-plugins/scrapy-playwright/issues/97#issuecomment-1159477767:

> would I be correct in saying that by setting PLAYWRIGHT_PROCESS_REQUEST_HEADERS = None, the User-Agent shouldn't be the default scrapy user agent, but rather the user agent set by playwright? Because when I have set it to None and then checked the request headers, the user agent is the default scrapy one.


Tasks:
- [x] Code fix
- [x] Tests