### PR TITLE
Support playwright_stealth

### DIFF
--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -198,7 +198,7 @@ class ScrapyPlaywrightDownloadHandler(HTTPDownloadHandler):
         page = await context.context.new_page()
         
         if self.enable_stealth is True:
-            page = stealth_async(page)
+            await stealth_async(page)
         
         self.stats.inc_value("playwright/page_count")
         logger.debug(

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,6 @@ setuptools.setup(
     install_requires=[
         "scrapy>=2.0,!=2.4.0",
         "playwright>=1.15",
+        "playwright-stealth>=1.0.5"
     ],
 )


### PR DESCRIPTION
Integrated playwright_stealth, and PLAYWRIGHT_STEALTH_ENABLED as an optional config.

Attached bot test results.

**PLAYWRIGHT_STEALTH_ENABLED = True**
![ENABLED](https://user-images.githubusercontent.com/29615986/181036474-1ce1a2ee-991f-47df-9104-21014e36e0c4.png)

**PLAYWRIGHT_STEALTH_ENABLED = False**
![DISABLED](https://user-images.githubusercontent.com/29615986/181036494-d495ddae-6ead-44ea-8c7c-e740202445af.png)

