### PR TITLE
Don't break if Page.goto returns None

### DIFF
--- a/tests/test_playwright_requests.py
+++ b/tests/test_playwright_requests.py
@@ -350,6 +350,22 @@ class MixinTestCase:
         assert headers["Referer"] == fake_referer
 
     @pytest.mark.asyncio
+    async def test_navigation_returns_none(self, caplog):
+        async with make_handler({"PLAYWRIGHT_BROWSER_TYPE": self.browser_type}) as handler:
+            with MockServer():
+                req = Request(url="about:blank", meta={"playwright": True})
+                response = await handler._download_request(req, Spider("spider_name"))
+
+        assert (
+            "scrapy-playwright",
+            logging.WARNING,
+            f"Navigating to {req!r} returned None, the response"
+            " will have empty headers and status 200",
+        ) in caplog.record_tuples
+        assert not response.headers
+        assert response.status == 200
+
+    @pytest.mark.asyncio
     async def test_abort_requests(self):
         async def should_abort_request_async(request):
             return request.resource_type == "image"


### PR DESCRIPTION
Closes #10, closes #102.

I'm still not entirely sure why the issues mentioned above occur, however this should provide a reasonable way for the crawl to proceed without errors in such cases.

From the [upstream docs on `Page.goto`](https://playwright.dev/python/docs/api/class-page#page-goto):
> The method either throws an error or returns a main resource response. The only exceptions are navigation to about:blank or navigation to the same URL with a different hash, which would succeed and return null.
