### PR TITLE
Fix request method override

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -7,6 +7,7 @@ disable=
     missing-function-docstring,
     missing-module-docstring,
     too-few-public-methods,
+    too-many-arguments,
     too-many-instance-attributes,
     too-many-locals,
     unused-argument,

--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -469,13 +469,14 @@ def _make_request_logger(context_name: str) -> Callable:
 def _make_response_logger(context_name: str) -> Callable:
     async def _log_request(response: PlaywrightResponse) -> None:
         referrer = await response.header_value("referer")
-        logger.debug(
-            "[Context=%s] Response: <%i %s> (referrer: %s)",
-            context_name,
-            response.status,
-            response.url,
-            referrer,
-        )
+        log_args = [context_name, response.status, response.url, referrer]
+        if 300 <= response.status < 400:
+            location = await response.header_value("location")
+            log_args.append(location)
+            msg = "[Context=%s] Response: <%i %s> (referrer: %s, location: %s)"
+        else:
+            msg = "[Context=%s] Response: <%i %s> (referrer: %s)"
+        logger.debug(msg, *log_args)
 
     return _log_request
 

--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -269,7 +269,8 @@ class ScrapyPlaywrightDownloadHandler(HTTPDownloadHandler):
             "**",
             self._make_request_handler(
                 method=request.method,
-                scrapy_headers=request.headers,
+                url=request.url,
+                headers=request.headers,
                 body=request.body,
                 encoding=request.encoding,
             ),
@@ -399,7 +400,12 @@ class ScrapyPlaywrightDownloadHandler(HTTPDownloadHandler):
         return close_browser_context_callback
 
     def _make_request_handler(
-        self, method: str, scrapy_headers: Headers, body: Optional[bytes], encoding: str = "utf8"
+        self,
+        method: str,
+        url: str,
+        headers: Headers,
+        body: Optional[bytes],
+        encoding: str = "utf8",
     ) -> Callable:
         async def _request_handler(route: Route, playwright_request: PlaywrightRequest) -> None:
             """Override request headers, method and body."""
@@ -417,17 +423,18 @@ class ScrapyPlaywrightDownloadHandler(HTTPDownloadHandler):
             else:
                 overrides["headers"] = final_headers = await _maybe_await(
                     self.process_request_headers(
-                        self.browser_type_name, playwright_request, scrapy_headers
+                        self.browser_type_name, playwright_request, headers
                     )
                 )
             # the request that reaches the callback should contain the final headers
-            scrapy_headers.clear()
-            scrapy_headers.update(final_headers)
+            headers.clear()
+            headers.update(final_headers)
             del final_headers
 
-            if playwright_request.is_navigation_request():
+            # if the request is triggered by scrapy, not playwright
+            if playwright_request.url == url:
                 overrides["method"] = method
-                if body is not None:
+                if body:
                     overrides["post_data"] = body.decode(encoding)
 
             try:

--- a/tests/test_playwright_requests.py
+++ b/tests/test_playwright_requests.py
@@ -125,10 +125,11 @@ class MixinTestCase:
         from unittest.mock import AsyncMock
 
         async with make_handler({"PLAYWRIGHT_BROWSER_TYPE": self.browser_type}) as handler:
-            req_handler = handler._make_request_handler("GET", Headers({}), body=None)
+            example_url = "https//example.org"
+            req_handler = handler._make_request_handler("GET", example_url, Headers({}), body=None)
             route = MagicMock()
             playwright_request = AsyncMock()
-            playwright_request.url = "https//example.org"
+            playwright_request.url = example_url
             playwright_request.is_navigation_request = MagicMock(return_value=True)
             playwright_request.all_headers.return_value = {}
 


### PR DESCRIPTION
Closes #100, closes #119, closes #143

I discovered the method for some navigation requests was incorrectly being overridden from POST to GET. This piece of code is there only because with `Page.goto` one can only trigger GET requests directly, however the URLs for the Playwright and Scrapy requests were not the same so the requests did not match each other. 