### PR TITLE
Set spider attribute on log records

### DIFF
--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -39,7 +39,8 @@ __all__ = ["ScrapyPlaywrightDownloadHandler"]
 PlaywrightHandler = TypeVar("PlaywrightHandler", bound="ScrapyPlaywrightDownloadHandler")
 
 
-logger = logging.getLogger("scrapy-playwright")
+LOGGER_NAME = "scrapy-playwright"
+logger = logging.getLogger(LOGGER_NAME)
 
 
 DEFAULT_BROWSER_TYPE = "chromium"
@@ -60,6 +61,7 @@ class ScrapyPlaywrightDownloadHandler(HTTPDownloadHandler):
         super().__init__(settings=settings, crawler=crawler)
         verify_installed_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
         crawler.signals.connect(self._engine_started, signals.engine_started)
+        crawler.signals.connect(self._spider_opened, signals.spider_opened)
         self.stats = crawler.stats
 
         # browser
@@ -108,6 +110,17 @@ class ScrapyPlaywrightDownloadHandler(HTTPDownloadHandler):
     def _engine_started(self) -> Deferred:
         """Launch the browser. Use the engine_started signal as it supports returning deferreds."""
         return deferred_from_coro(self._launch())
+
+    def _spider_opened(self, spider: Spider) -> None:
+        old_factory = logging.getLogRecordFactory()
+
+        def record_factory(name: str, *args, **kwargs):
+            record = old_factory(name, *args, **kwargs)
+            if name == LOGGER_NAME:
+                record.spider = spider
+            return record
+
+        logging.setLogRecordFactory(record_factory)
 
     async def _launch(self) -> None:
         """Launch Playwright manager and configured startup context(s)."""


### PR DESCRIPTION
Closes #155

Log records emitted after the spider is opened will have a `spider` attribute.

Pattern taken from https://docs.python.org/3/library/logging.html#logrecord-objects.