### PR TITLE
Override method only for navigation requests

### DIFF
--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -500,7 +500,10 @@ class ScrapyPlaywrightDownloadHandler(HTTPDownloadHandler):
 
             # if the request is triggered by scrapy, not playwright
             original_playwright_method: str = playwright_request.method
-            if playwright_request.url == url:
+            if (
+                playwright_request.url.rstrip("/") == url.rstrip("/")
+                and playwright_request.is_navigation_request()
+            ):
                 if method.upper() != playwright_request.method.upper():
                     overrides["method"] = method
                 if body:


### PR DESCRIPTION
Fixes #176

Introduced at #144, seems like both checks are necessary.