### PR TITLE
Improve concurrency on Windows

### DIFF
--- a/scrapy_playwright/_utils.py
+++ b/scrapy_playwright/_utils.py
@@ -111,10 +111,9 @@ if platform.system() == "Windows":
         @classmethod
         async def _handle_coro(cls, coro, future) -> None:
             try:
-                result = await coro
-                future.set_result(result)
-            except Exception as e:
-                future.set_exception(e)
+                future.set_result(await coro)
+            except Exception as exc:
+                future.set_exception(exc)
 
         @classmethod
         async def _process_queue(cls) -> None:

--- a/scrapy_playwright/_utils.py
+++ b/scrapy_playwright/_utils.py
@@ -122,10 +122,11 @@ if platform.system() == "Windows":
 
         @classmethod
         async def get_result(cls, coro) -> concurrent.futures.Future:
-            return asyncio.run_coroutine_threadsafe(coro=coro, loop=cls.get_event_loop()).result()
+            return asyncio.run_coroutine_threadsafe(coro=coro, loop=cls.get_event_loop())
 
     def _deferred_from_coro(coro) -> Deferred:
-        return scrapy.utils.defer.deferred_from_coro(_WindowsAdapter.get_result(coro))
+        dfd = scrapy.utils.defer.deferred_from_coro(_WindowsAdapter.get_result(coro))
+        return dfd.addCallback(lambda future: future.result())
 
 else:
     _deferred_from_coro = scrapy.utils.defer.deferred_from_coro

--- a/scrapy_playwright/_utils.py
+++ b/scrapy_playwright/_utils.py
@@ -131,10 +131,7 @@ if platform.system() == "Windows":
 
         @classmethod
         def start(cls) -> None:
-            try:
-                policy = asyncio.WindowsProactorEventLoopPolicy()  # type: ignore[attr-defined]
-            except AttributeError:
-                policy = asyncio.DefaultEventLoopPolicy()
+            policy = asyncio.WindowsProactorEventLoopPolicy()  # type: ignore[attr-defined]
             cls._loop = policy.new_event_loop()
             asyncio.set_event_loop(cls._loop)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -17,7 +17,7 @@ if platform.system() == "Windows":
     from scrapy_playwright._utils import _ThreadedLoopAdapter
 
     def allow_windows(test_method):
-        """Wrap tests with the _WindowsAdapter class on Windows."""
+        """Wrap tests with the _ThreadedLoopAdapter class on Windows."""
         if not inspect.iscoroutinefunction(test_method):
             raise RuntimeError(f"{test_method} must be an async def method")
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import logging
 import platform
@@ -22,8 +23,10 @@ if platform.system() == "Windows":
 
         @wraps(test_method)
         async def wrapped(self, *args, **kwargs):
-            logger.debug("Calling _WindowsAdapter.get_result for %r", self)
-            await _ThreadedLoopAdapter.get_result(test_method(self, *args, **kwargs))
+            _ThreadedLoopAdapter.start()
+            coro = test_method(self, *args, **kwargs)
+            asyncio.run_coroutine_threadsafe(coro=coro, loop=_ThreadedLoopAdapter._loop).result()
+            _ThreadedLoopAdapter.stop()
 
         return wrapped
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("scrapy-playwright-tests")
 
 
 if platform.system() == "Windows":
-    from scrapy_playwright._utils import _WindowsAdapter
+    from scrapy_playwright._utils import _ThreadedLoopAdapter
 
     def allow_windows(test_method):
         """Wrap tests with the _WindowsAdapter class on Windows."""
@@ -23,7 +23,7 @@ if platform.system() == "Windows":
         @wraps(test_method)
         async def wrapped(self, *args, **kwargs):
             logger.debug("Calling _WindowsAdapter.get_result for %r", self)
-            await _WindowsAdapter.get_result(test_method(self, *args, **kwargs))
+            await _ThreadedLoopAdapter.get_result(test_method(self, *args, **kwargs))
 
         return wrapped
 

--- a/tests/tests_twisted/test_mixed_requests.py
+++ b/tests/tests_twisted/test_mixed_requests.py
@@ -19,7 +19,9 @@ class MixedRequestsTestCase(TestCase):
     def setUp(self):
         self.server = StaticMockServer()
         self.server.__enter__()
-        self.handler = ScrapyPlaywrightDownloadHandler.from_crawler(get_crawler())
+        self.handler = ScrapyPlaywrightDownloadHandler.from_crawler(
+            get_crawler(settings_dict={"PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 500})
+        )
         yield self.handler._engine_started()
 
     @defer.inlineCallbacks
@@ -29,26 +31,34 @@ class MixedRequestsTestCase(TestCase):
 
     @defer.inlineCallbacks
     def test_download_request(self):
-        def _test_regular(response, request):
+        def _check_regular(response, request):
             self.assertIsInstance(response, Response)
             self.assertEqual(response.css("a::text").getall(), ["Lorem Ipsum", "Infinite Scroll"])
             self.assertEqual(response.url, request.url)
             self.assertEqual(response.status, 200)
             self.assertNotIn("playwright", response.flags)
 
-        def _test_playwright(response, request):
+        def _check_playwright_ok(response, request):
             self.assertIsInstance(response, Response)
             self.assertEqual(response.css("a::text").getall(), ["Lorem Ipsum", "Infinite Scroll"])
             self.assertEqual(response.url, request.url)
             self.assertEqual(response.status, 200)
             self.assertIn("playwright", response.flags)
 
+        def _check_playwright_error(failure, url):
+            self.assertIn(f"Page.goto: net::ERR_CONNECTION_REFUSED at {url}", str(failure.value))
+
         req1 = Request(self.server.urljoin("/index.html"))
         yield self.handler.download_request(req1, Spider("foo")).addCallback(
-            _test_regular, request=req1
+            _check_regular, request=req1
         )
 
         req2 = Request(self.server.urljoin("/index.html"), meta={"playwright": True})
         yield self.handler.download_request(req2, Spider("foo")).addCallback(
-            _test_playwright, request=req2
+            _check_playwright_ok, request=req2
+        )
+
+        req3 = Request("http://localhost:12345/asdf", meta={"playwright": True})
+        yield self.handler.download_request(req3, Spider("foo")).addErrback(
+            _check_playwright_error, url=req3.url
         )


### PR DESCRIPTION
Closes #282

Alternative approach to #285

This yields full concurrency (`'playwright/page_count/max_concurrent': 32` in stats) with the sample spider from #285:
```python
import scrapy

class DelayTest(scrapy.Spider):
    name = "delay"
    custom_settings = {
        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
        "DOWNLOAD_HANDLERS": {
            # "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
            "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
        },
        "PLAYWRIGHT_MAX_PAGES_PER_CONTEXT": 32,
        "CONCURRENT_REQUESTS_PER_IP": 32,
        "CONCURRENT_REQUESTS_PER_DOMAIN": 32,
        "CONCURRENT_REQUESTS": 32,
        "PLAYWRIGHT_LAUNCH_OPTIONS": {"headless": False},
    }

    def start_requests(self):
        for i in range(32):
            yield scrapy.Request(
                url=f"https://httpbin.org/delay/1?i={i}",
                meta={"playwright": True},
            )

    def parse(self, response):
        print(response.url)
```