### PR TITLE
Fix 204 status freezing the crawl

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,19 @@ def parse(self, response, **kwargs):
     # {'issuer': 'DigiCert TLS RSA SHA256 2020 CA1', 'protocol': 'TLS 1.3', 'subjectName': 'www.example.org', 'validFrom': 1647216000, 'validTo': 1678838399}
 ```
 
+### `playwright_suggested_filename`
+Type `Optional[str]`, read only
+
+The value of the [`Download.suggested_filename`](https://playwright.dev/python/docs/api/class-download#download-suggested-filename)
+attribute when the response is the binary contents of a download (e.g. a PDF file)
+Only available for responses that only caused a download. Could be accessed
+in the callback via `response.meta['playwright_suggested_filename']`
+
+```python
+def parse(self, response, **kwargs):
+    print(response.meta["playwright_suggested_filename"])
+    # 'sample_file.pdf'
+```
 
 ## Receiving Page objects in callbacks
 

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -59,6 +59,9 @@ class _RequestHandler(BaseHTTPRequestHandler):
 
         if parsed_path.path == "/headers":
             self._send_json(dict(self.headers))
+        elif parsed_path.path == "/status/204":
+            self.send_response(204)
+            self.end_headers()
         elif parsed_path.path == "/redirect2":
             self.send_response(302)
             self.send_header("Content-Length", "0")

--- a/tests/tests_asyncio/test_playwright_requests.py
+++ b/tests/tests_asyncio/test_playwright_requests.py
@@ -465,6 +465,23 @@ class MixinTestCase:
                     f" exc_type={type(excinfo.value)} exc_msg={str(excinfo.value)}",
                 ) in self._caplog.record_tuples
 
+    @allow_windows
+    async def test_fail_status_204(self):
+        async with make_handler({"PLAYWRIGHT_BROWSER_TYPE": self.browser_type}) as handler:
+            with MockServer() as server:
+                request = Request(
+                    url=server.urljoin("/status/204"),
+                    meta={"playwright": True},
+                )
+                with pytest.raises(PlaywrightError) as excinfo:
+                    await handler._download_request(request, Spider("foo"))
+                assert (
+                    "scrapy-playwright",
+                    logging.WARNING,
+                    f"Closing page due to failed request: {request}"
+                    f" exc_type={type(excinfo.value)} exc_msg={str(excinfo.value)}",
+                ) in self._caplog.record_tuples
+
 
 class TestCaseChromium(IsolatedAsyncioTestCase, MixinTestCase):
     browser_type = "chromium"


### PR DESCRIPTION
Closes #288

* Fix 204 status responses freezing the crawl
* Return proper status code and headers for downloads