### PR TITLE
fix(handler): fix download response header Content-Encoding error  #321

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ coverage-twisted/
 node_modules/
 package-lock.json
 package.json
+
+.idea

--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -503,10 +503,12 @@ class ScrapyPlaywrightDownloadHandler(HTTPDownloadHandler):
         if download:
             request.meta["playwright_suggested_filename"] = download.suggested_filename
             respcls = responsetypes.from_args(url=download.url, body=download.body)
+            download_headers = Headers(download.headers)
+            download_headers.pop("Content-Encoding", None)
             return respcls(
                 url=download.url,
                 status=download.response_status,
-                headers=Headers(download.headers),
+                headers=download_headers,
                 body=download.body,
                 request=request,
                 flags=["playwright"],


### PR DESCRIPTION
This pull request includes a small but important change to the `scrapy_playwright/handler.py` file. The change involves modifying the handling of download headers to remove the `Content-Encoding` header before creating the response object.

* [`scrapy_playwright/handler.py`](diffhunk://#diff-7fb813bf258cb36a87e3852da4ac4816515ce427f9311af8e2729c63b92b9d5aR506-R511): In the `_download_request_with_page` method, added logic to remove the `Content-Encoding` header from download headers before creating the response object.

[[](url)](https://github.com/scrapy-plugins/scrapy-playwright/issues/321)