### PR TITLE
Add support for Scrapy 2.14 download handler API.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setuptools.setup(
     ],
     python_requires=">=3.9",
     install_requires=[
+        "packaging>=20.0",
         "scrapy>=2.0,!=2.4.0",
         "playwright>=1.15",
     ],


### PR DESCRIPTION
For https://github.com/scrapy/scrapy/pull/7164

This is kind of a proof of concept, but it passes tests on Linux both in this state (so using Scrapy 2.13) and with modifications for the unreleased Scrapy (installing Scrapy from the branch, changing _ASYNC_HANDLER_API to True).

I haven't tested this on Windows, but I kept `_deferred_from_coro()` calls, so it should work (as an aside, with almost all Scrapy API preferring coroutines now, it would be easier to not have these calls and double conversions, maybe `_ThreadedLoopAdapter` can be extended to also take coros directly).