### PR TITLE
Suppress PlaywrightError on response.security_details() and server_addr()

### DIFF
--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -535,8 +535,8 @@ class ScrapyPlaywrightDownloadHandler(HTTP11DownloadHandler):
 
         server_ip_address = None
         if response is not None:
-            request.meta["playwright_security_details"] = await response.security_details()
-            with suppress(KeyError, TypeError, ValueError):
+            with suppress(PlaywrightError, KeyError, TypeError, ValueError):
+                request.meta["playwright_security_details"] = await response.security_details()
                 server_addr = await response.server_addr()
                 server_ip_address = ip_address(server_addr["ipAddress"])
 

--- a/tests/tests_asyncio/test_playwright_requests.py
+++ b/tests/tests_asyncio/test_playwright_requests.py
@@ -571,6 +571,32 @@ class MixinTestCase:
                     f" exc_type={type(excinfo.value)} exc_msg={str(excinfo.value)}",
                 ) in self._caplog.record_tuples
 
+    @allow_windows
+    async def test_response_attributes_when_playwright_error(self):
+        collected_error = PlaywrightError(
+            "The object has been collected to prevent unbounded heap growth."
+        )
+        async with make_handler({"PLAYWRIGHT_BROWSER_TYPE": self.browser_type}) as handler:
+            with MockServer() as server:
+                request = Request(
+                    url=server.urljoin("/headers"),
+                    meta={"playwright": True},
+                )
+                with patch(
+                    "playwright.async_api._generated.Response.security_details",
+                    new_callable=AsyncMock,
+                    side_effect=collected_error,
+                ), patch(
+                    "playwright.async_api._generated.Response.server_addr",
+                    new_callable=AsyncMock,
+                    side_effect=collected_error,
+                ):
+                    response = await handler._download_request(request, Spider("foo"))
+
+        assert response.status == 200
+        assert "playwright_security_details" not in request.meta
+        assert response.ip_address is None
+
 
 class TestCaseChromium(IsolatedAsyncioTestCase, MixinTestCase):
     browser_type = "chromium"


### PR DESCRIPTION
## Summary

- Wrap `response.security_details()` and `response.server_addr()` with `suppress(PlaywrightError)` to prevent request failures when Playwright garbage collects response objects
- Add test covering the GC scenario for both methods

Fixes #363

## Test plan

- [ ] Existing tests pass
- [ ] New test `test_response_attributes_collected` verifies requests succeed when both `security_details()` and `server_addr()` raise `PlaywrightError`