### PR TITLE
Wrap response.security_details() in suppress(PlaywrightError) to handle closed pages

### DIFF
--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -535,7 +535,8 @@ class ScrapyPlaywrightDownloadHandler(HTTP11DownloadHandler):
 
         server_ip_address = None
         if response is not None:
-            request.meta["playwright_security_details"] = await response.security_details()
+            with suppress(PlaywrightError):
+                request.meta["playwright_security_details"] = await response.security_details()
             with suppress(KeyError, TypeError, ValueError):
                 server_addr = await response.server_addr()
                 server_ip_address = ip_address(server_addr["ipAddress"])


### PR DESCRIPTION
When a page or context gets closed before `response.security_details()` is awaited, Playwright raises a `PlaywrightError` (`Target closed` or similar). This crashes the whole request instead of just skipping the security details.

The adjacent `response.server_addr()` call is already wrapped in `suppress(KeyError, TypeError, ValueError)`, so this is an oversight.

Fix: wrap `response.security_details()` in `suppress(PlaywrightError)`, matching how the server address call is handled. `PlaywrightError` is already imported and `suppress` is already imported from `contextlib`.

Reproducer from issue #363:
```
playwright._impl._errors.TargetClosedError: Target page, context or browser has been closed
  ...handler.py, line 492, in _download_request
    request.meta["playwright_security_details"] = await response.security_details()
```

Closes #363