### PR TITLE
Release semaphore on context creation failure

### DIFF
--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -256,24 +256,31 @@ class ScrapyPlaywrightDownloadHandler(HTTP11DownloadHandler):
         """Create a new context, also launching a local browser or connecting
         to a remote one if necessary.
         """
+        acquired = False
         if hasattr(self, "context_semaphore"):
             await self.context_semaphore.acquire()
-        context_kwargs = context_kwargs or {}
-        persistent = remote = False
-        if context_kwargs.get(PERSISTENT_CONTEXT_PATH_KEY):
-            context = await self.browser_type.launch_persistent_context(**context_kwargs)
-            persistent = True
-        elif self.config.cdp_url:
-            await self._maybe_connect_remote_devtools()
-            context = await self.browser.new_context(**context_kwargs)
-            remote = True
-        elif self.config.connect_url:
-            await self._maybe_connect_remote()
-            context = await self.browser.new_context(**context_kwargs)
-            remote = True
-        else:
-            await self._maybe_launch_browser()
-            context = await self.browser.new_context(**context_kwargs)
+            acquired = True
+        try:
+            context_kwargs = context_kwargs or {}
+            persistent = remote = False
+            if context_kwargs.get(PERSISTENT_CONTEXT_PATH_KEY):
+                context = await self.browser_type.launch_persistent_context(**context_kwargs)
+                persistent = True
+            elif self.config.cdp_url:
+                await self._maybe_connect_remote_devtools()
+                context = await self.browser.new_context(**context_kwargs)
+                remote = True
+            elif self.config.connect_url:
+                await self._maybe_connect_remote()
+                context = await self.browser.new_context(**context_kwargs)
+                remote = True
+            else:
+                await self._maybe_launch_browser()
+                context = await self.browser.new_context(**context_kwargs)
+        except Exception:
+            if acquired:
+                self.context_semaphore.release()
+            raise
 
         context.on(
             "close", self._make_close_browser_context_callback(name, persistent, remote, spider)

--- a/tests/tests_asyncio/test_browser_contexts.py
+++ b/tests/tests_asyncio/test_browser_contexts.py
@@ -3,10 +3,15 @@ import platform
 import tempfile
 from pathlib import Path
 from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
-from playwright.async_api import Browser, TimeoutError as PlaywrightTimeoutError
+from playwright.async_api import (
+    Browser,
+    Error as PlaywrightError,
+    TimeoutError as PlaywrightTimeoutError,
+)
 from scrapy import Spider, Request
 from scrapy_playwright.page import PageMethod
 
@@ -188,6 +193,52 @@ class MixinTestCaseMultipleContexts:
             assert handler.context_wrappers["persistent"].persistent
             assert not handler.context_wrappers["non-persistent"].persistent
             assert isinstance(handler.browser, Browser)
+
+    @allow_windows
+    async def test_context_semaphore_not_leaked_on_context_creation_failure(self):
+        """Failure on context creation must not leak a semaphore slot,
+        causing subsequent context creation to hang.
+        """
+        settings = {
+            "PLAYWRIGHT_BROWSER_TYPE": self.browser_type,
+            "PLAYWRIGHT_MAX_CONTEXTS": 1,
+        }
+        async with make_handler(settings) as handler:
+            assert hasattr(handler, "context_semaphore")
+            assert handler.context_semaphore._value == 1
+
+            with StaticMockServer() as server:
+                req = Request(server.urljoin("/index.html"), meta={"playwright": True})
+                await handler._download_request(req, Spider("foo"))
+                assert handler.context_semaphore._value == 0
+
+                await handler.context_wrappers["default"].context.close()
+                await asyncio.sleep(0)  # allow the close task to release the semaphore
+                assert handler.context_semaphore._value == 1
+
+                with patch.object(
+                    handler.browser,
+                    "new_context",
+                    new_callable=AsyncMock,
+                    side_effect=PlaywrightError("simulated new_context failure"),
+                ):
+                    with pytest.raises(PlaywrightError):
+                        await handler._create_browser_context(
+                            name="failing-ctx",
+                            context_kwargs={},
+                            spider=Spider("foo"),
+                        )
+
+                assert handler.context_semaphore._value == 1
+
+                req2 = Request(
+                    server.urljoin("/index.html"),
+                    meta={"playwright": True, "playwright_context": "default2"},
+                )
+                await asyncio.wait_for(
+                    handler._download_request(req2, Spider("foo")),
+                    timeout=15.0,
+                )
 
     @allow_windows
     async def test_contexts_dynamic(self):


### PR DESCRIPTION
Similar to #368

The context creation semaphore that enforces `PLAYWRIGHT_MAX_CONTEXTS` is not released if something goes wrong when creating a new context, potentially causing the context limit to be reached.