### PR TITLE
Better response/download event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ timeout is exceeded, the original navigation error is re-raised instead of
 hanging indefinitely.
 
 ```python
-PLAYWRIGHT_DOWNLOAD_TIMEOUT = 60  # 1 minute
+PLAYWRIGHT_DOWNLOAD_TIMEOUT = 60000  # 1 minute
 ```
 
 ### `PLAYWRIGHT_PROCESS_REQUEST_HEADERS`

--- a/README.md
+++ b/README.md
@@ -282,6 +282,17 @@ See the docs for [BrowserContext.set_default_navigation_timeout](https://playwri
 PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT = 10 * 1000  # 10 seconds
 ```
 
+### `PLAYWRIGHT_DOWNLOAD_TIMEOUT`
+Type `int`, default `30`
+
+Timeout in seconds to wait for a file download to start and to finish. If the
+timeout is exceeded, the original navigation error is re-raised instead of
+hanging indefinitely.
+
+```python
+PLAYWRIGHT_DOWNLOAD_TIMEOUT = 60  # 1 minute
+```
+
 ### `PLAYWRIGHT_PROCESS_REQUEST_HEADERS`
 Type `Optional[Union[Callable, str]]`, default `scrapy_playwright.headers.use_scrapy_headers`
 

--- a/README.md
+++ b/README.md
@@ -283,9 +283,9 @@ PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT = 10 * 1000  # 10 seconds
 ```
 
 ### `PLAYWRIGHT_DOWNLOAD_TIMEOUT`
-Type `int`, default `30`
+Type `int`, default `30000` (30 seconds)
 
-Timeout in seconds to wait for a file download to start and to finish. If the
+Timeout in milliseconds to wait for a file download to start and to finish. If the
 timeout is exceeded, the original navigation error is re-raised instead of
 hanging indefinitely.
 

--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -643,8 +643,8 @@ class ScrapyPlaywrightDownloadHandler(HTTP11DownloadHandler):
                     download_started.wait(),
                     timeout=self.config.download_timeout,
                 )
-            except asyncio.TimeoutError:
-                raise err
+            except asyncio.TimeoutError as exc:
+                raise err from exc
 
             if download.response_status == 204:
                 raise err
@@ -664,8 +664,8 @@ class ScrapyPlaywrightDownloadHandler(HTTP11DownloadHandler):
                     download_ready.wait(),
                     timeout=self.config.download_timeout,
                 )
-            except asyncio.TimeoutError:
-                raise err
+            except asyncio.TimeoutError as exc:
+                raise err from exc
         finally:
             page.remove_listener("download", _handle_download)
             page.remove_listener("response", _handle_response)

--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -95,8 +95,8 @@ class Config:
     max_pages_per_context: int
     max_contexts: Optional[int]
     startup_context_kwargs: dict
-    navigation_timeout: Optional[float]
-    download_timeout: int
+    navigation_timeout_ms: Optional[float]
+    download_timeout_secs: float
     restart_disconnected_browser: bool
     target_closed_max_retries: int = 3
     use_threaded_loop: bool = False
@@ -117,10 +117,11 @@ class Config:
             max_pages_per_context=settings.getint("PLAYWRIGHT_MAX_PAGES_PER_CONTEXT"),
             max_contexts=settings.getint("PLAYWRIGHT_MAX_CONTEXTS") or None,
             startup_context_kwargs=settings.getdict("PLAYWRIGHT_CONTEXTS"),
-            navigation_timeout=_get_float_setting(
+            navigation_timeout_ms=_get_float_setting(
                 settings, "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT"
             ),
-            download_timeout=settings.getint("PLAYWRIGHT_DOWNLOAD_TIMEOUT", default=30),
+            download_timeout_secs=settings.getint("PLAYWRIGHT_DOWNLOAD_TIMEOUT", default=30000)
+            / 1000,
             restart_disconnected_browser=settings.getbool(
                 "PLAYWRIGHT_RESTART_DISCONNECTED_BROWSER", default=True
             ),
@@ -302,8 +303,8 @@ class ScrapyPlaywrightDownloadHandler(HTTP11DownloadHandler):
                 "remote": remote,
             },
         )
-        if self.config.navigation_timeout is not None:
-            context.set_default_navigation_timeout(self.config.navigation_timeout)
+        if self.config.navigation_timeout_ms is not None:
+            context.set_default_navigation_timeout(self.config.navigation_timeout_ms)
         self.context_wrappers[name] = BrowserContextWrapper(
             context=context,
             semaphore=asyncio.Semaphore(value=self.config.max_pages_per_context),
@@ -349,8 +350,8 @@ class ScrapyPlaywrightDownloadHandler(HTTP11DownloadHandler):
             },
         )
         self._set_max_concurrent_page_count()
-        if self.config.navigation_timeout is not None:
-            page.set_default_navigation_timeout(self.config.navigation_timeout)
+        if self.config.navigation_timeout_ms is not None:
+            page.set_default_navigation_timeout(self.config.navigation_timeout_ms)
 
         page.on("close", self._make_close_page_callback(context_name))
         page.on("crash", self._make_close_page_callback(context_name))
@@ -641,7 +642,7 @@ class ScrapyPlaywrightDownloadHandler(HTTP11DownloadHandler):
             try:
                 await asyncio.wait_for(
                     download_started.wait(),
-                    timeout=self.config.download_timeout,
+                    timeout=self.config.download_timeout_secs,
                 )
             except asyncio.TimeoutError as exc:
                 raise err from exc
@@ -662,7 +663,7 @@ class ScrapyPlaywrightDownloadHandler(HTTP11DownloadHandler):
             try:
                 await asyncio.wait_for(
                     download_ready.wait(),
-                    timeout=self.config.download_timeout,
+                    timeout=self.config.download_timeout_secs,
                 )
             except asyncio.TimeoutError as exc:
                 raise err from exc
@@ -699,7 +700,7 @@ class ScrapyPlaywrightDownloadHandler(HTTP11DownloadHandler):
                     )
                 else:
                     pm.result = await _maybe_await(method(*pm.args, **pm.kwargs))
-                    await page.wait_for_load_state(timeout=self.config.navigation_timeout)
+                    await page.wait_for_load_state(timeout=self.config.navigation_timeout_ms)
             else:
                 logger.warning(
                     "Ignoring %r: expected PageMethod, got %r",

--- a/scrapy_playwright/handler.py
+++ b/scrapy_playwright/handler.py
@@ -96,6 +96,7 @@ class Config:
     max_contexts: Optional[int]
     startup_context_kwargs: dict
     navigation_timeout: Optional[float]
+    download_timeout: int
     restart_disconnected_browser: bool
     target_closed_max_retries: int = 3
     use_threaded_loop: bool = False
@@ -119,6 +120,7 @@ class Config:
             navigation_timeout=_get_float_setting(
                 settings, "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT"
             ),
+            download_timeout=settings.getint("PLAYWRIGHT_DOWNLOAD_TIMEOUT", default=30),
             restart_disconnected_browser=settings.getbool(
                 "PLAYWRIGHT_RESTART_DISCONNECTED_BROWSER", default=True
             ),
@@ -636,7 +638,13 @@ class ScrapyPlaywrightDownloadHandler(HTTP11DownloadHandler):
                     "scrapy_request_method": request.method,
                 },
             )
-            await download_started.wait()
+            try:
+                await asyncio.wait_for(
+                    download_started.wait(),
+                    timeout=self.config.download_timeout,
+                )
+            except asyncio.TimeoutError:
+                raise err
 
             if download.response_status == 204:
                 raise err
@@ -651,7 +659,13 @@ class ScrapyPlaywrightDownloadHandler(HTTP11DownloadHandler):
                     "scrapy_request_method": request.method,
                 },
             )
-            await download_ready.wait()
+            try:
+                await asyncio.wait_for(
+                    download_ready.wait(),
+                    timeout=self.config.download_timeout,
+                )
+            except asyncio.TimeoutError:
+                raise err
         finally:
             page.remove_listener("download", _handle_download)
             page.remove_listener("response", _handle_response)

--- a/tests/tests_asyncio/test_playwright_requests.py
+++ b/tests/tests_asyncio/test_playwright_requests.py
@@ -572,6 +572,37 @@ class MixinTestCase:
                 ) in self._caplog.record_tuples
 
     @allow_windows
+    async def test_err_aborted_without_download_does_not_hang(self):
+        """net::ERR_ABORTED without a download event must not deadlock.
+
+        When Chromium aborts a navigation for a non-download reason (e.g. a
+        JS challenge redirecting mid-load), neither the "response" nor
+        the "download" page event fires. The handler was previously waiting
+        on the download_started event, hence blocking forever.
+
+        Current behaviour is to propagate the original Playwright Error after
+        {PLAYWRIGHT_DOWNLOAD_TIMEOUT} seconds. The test wraps the call in
+        ``asyncio.wait_for``, a TimeoutError here means a deadlock is occurring.
+        """
+        if self.browser_type != "chromium":
+            pytest.skip("net::ERR_ABORTED deadlock only affects Chromium")
+
+        mock_page = MagicMock()
+        mock_page.goto = AsyncMock(side_effect=PlaywrightError("net::ERR_ABORTED"))
+
+        settings = {
+            "PLAYWRIGHT_BROWSER_TYPE": self.browser_type,
+            "PLAYWRIGHT_DOWNLOAD_TIMEOUT": 1,
+        }
+        async with make_handler(settings) as handler:
+            request = Request("https://example.com", meta={"playwright": True})
+            with pytest.raises(PlaywrightError):
+                await asyncio.wait_for(
+                    handler._get_response_and_download(request, mock_page, Spider("foo")),
+                    timeout=5.0,  # bigger than PLAYWRIGHT_DOWNLOAD_TIMEOUT
+                )
+
+    @allow_windows
     async def test_response_attributes_when_playwright_error(self):
         collected_error = PlaywrightError(
             "The object has been collected to prevent unbounded heap growth."

--- a/tests/tests_asyncio/test_playwright_requests.py
+++ b/tests/tests_asyncio/test_playwright_requests.py
@@ -511,7 +511,8 @@ class MixinTestCase:
     async def test_download_file_delay_error(self):
         settings_dict = {
             "PLAYWRIGHT_BROWSER_TYPE": self.browser_type,
-            "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 10,
+            "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 100,
+            "PLAYWRIGHT_DOWNLOAD_TIMEOUT": 100,
         }
         async with make_handler(settings_dict) as handler:
             with MockServer() as server:
@@ -581,7 +582,7 @@ class MixinTestCase:
         on the download_started event, hence blocking forever.
 
         Current behaviour is to propagate the original Playwright Error after
-        {PLAYWRIGHT_DOWNLOAD_TIMEOUT} seconds. The test wraps the call in
+        {PLAYWRIGHT_DOWNLOAD_TIMEOUT} milliseconds. The test wraps the call in
         ``asyncio.wait_for``, a TimeoutError here means a deadlock is occurring.
         """
         if self.browser_type != "chromium":
@@ -592,14 +593,14 @@ class MixinTestCase:
 
         settings = {
             "PLAYWRIGHT_BROWSER_TYPE": self.browser_type,
-            "PLAYWRIGHT_DOWNLOAD_TIMEOUT": 1,
+            "PLAYWRIGHT_DOWNLOAD_TIMEOUT": 100,
         }
         async with make_handler(settings) as handler:
             request = Request("https://example.com", meta={"playwright": True})
             with pytest.raises(PlaywrightError):
                 await asyncio.wait_for(
                     handler._get_response_and_download(request, mock_page, Spider("foo")),
-                    timeout=5.0,  # bigger than PLAYWRIGHT_DOWNLOAD_TIMEOUT
+                    timeout=1.0,  # bigger than PLAYWRIGHT_DOWNLOAD_TIMEOUT (1000ms = 1s)
                 )
 
     @allow_windows

--- a/tests/tests_asyncio/test_playwright_requests.py
+++ b/tests/tests_asyncio/test_playwright_requests.py
@@ -604,6 +604,48 @@ class MixinTestCase:
                 )
 
     @allow_windows
+    async def test_download_ready_timeout(self):
+        """Download starts (response fires) but never finishes within the timeout.
+
+        When a navigation raises PlaywrightError and the response event fires
+        (so download_started is set and the response status is not 204), but the
+        download event never fires, the handler should time out waiting for
+        download_ready and re-raise the original PlaywrightError.
+        """
+        listeners = {}
+
+        def register_listener(event, callback):
+            listeners[event] = callback
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.all_headers = AsyncMock(return_value={})
+
+        playwright_error = PlaywrightError("Download is starting")
+
+        async def mock_goto(*_args, **_kwargs):
+            asyncio.create_task(listeners["response"](mock_response))
+            await asyncio.sleep(0)  # let the response task set download_started
+            raise playwright_error
+
+        mock_page = MagicMock()
+        mock_page.on = MagicMock(side_effect=register_listener)
+        mock_page.goto = mock_goto
+
+        settings = {
+            "PLAYWRIGHT_BROWSER_TYPE": self.browser_type,
+            "PLAYWRIGHT_DOWNLOAD_TIMEOUT": 100,
+        }
+        async with make_handler(settings) as handler:
+            request = Request("https://example.com", meta={"playwright": True})
+            with pytest.raises(PlaywrightError) as excinfo:
+                await asyncio.wait_for(
+                    handler._get_response_and_download(request, mock_page, Spider("foo")),
+                    timeout=1.0,  # bigger than PLAYWRIGHT_DOWNLOAD_TIMEOUT (100ms)
+                )
+            assert excinfo.value is playwright_error
+
+    @allow_windows
     async def test_response_attributes_when_playwright_error(self):
         collected_error = PlaywrightError(
             "The object has been collected to prevent unbounded heap growth."

--- a/tests/tests_asyncio/test_settings.py
+++ b/tests/tests_asyncio/test_settings.py
@@ -12,19 +12,19 @@ from tests import allow_windows, make_handler
 class TestSettings(IsolatedAsyncioTestCase):
     async def test_settings_timeout_value(self):
         config = Config.from_settings(Settings({}))
-        assert config.navigation_timeout is None
+        assert config.navigation_timeout_ms is None
 
         config = Config.from_settings(Settings({"PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": None}))
-        assert config.navigation_timeout is None
+        assert config.navigation_timeout_ms is None
 
         config = Config.from_settings(Settings({"PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 0}))
-        assert config.navigation_timeout == 0
+        assert config.navigation_timeout_ms == 0
 
         config = Config.from_settings(Settings({"PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 123}))
-        assert config.navigation_timeout == 123
+        assert config.navigation_timeout_ms == 123
 
         config = Config.from_settings(Settings({"PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 0.5}))
-        assert config.navigation_timeout == 0.5
+        assert config.navigation_timeout_ms == 0.5
 
     async def test_max_pages_per_context(self):
         config = Config.from_settings(Settings({"PLAYWRIGHT_MAX_PAGES_PER_CONTEXT": 1234}))


### PR DESCRIPTION
Closes #371

* Add a timeout to the waiting on response/download events
* Add `PLAYWRIGHT_DOWNLOAD_TIMEOUT: int` setting

The new test fails on the current `main` code, passes with this patch.